### PR TITLE
fix(controller): managedby label of flux and object reconciler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/fluxcd/pkg/apis/meta v1.22.0
 	github.com/fluxcd/source-controller/api v1.7.3
 	github.com/go-logr/logr v1.4.3
-	github.com/openmcp-project/control-plane-operator v0.1.18
+	github.com/openmcp-project/control-plane-operator v0.1.19
 	github.com/openmcp-project/controller-utils v0.23.2
 	github.com/openmcp-project/openmcp-operator/api v0.17.0
 	github.com/openmcp-project/openmcp-operator/lib v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -151,8 +151,8 @@ github.com/onsi/ginkgo/v2 v2.27.2 h1:LzwLj0b89qtIy6SSASkzlNvX6WktqurSHwkk2ipF/Ns
 github.com/onsi/ginkgo/v2 v2.27.2/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.38.2 h1:eZCjf2xjZAqe+LeWvKb5weQ+NcPwX84kqJ0cZNxok2A=
 github.com/onsi/gomega v1.38.2/go.mod h1:W2MJcYxRGV63b418Ai34Ud0hEdTVXq9NW9+Sx6uXf3k=
-github.com/openmcp-project/control-plane-operator v0.1.18 h1:osgQthErzXesiPJt/sDuiDjvpa8BJetE/ZKUNpwjKQQ=
-github.com/openmcp-project/control-plane-operator v0.1.18/go.mod h1:8nwJfUITC7T8G77H0koXlEDfGeg13aWJyCsvg5iqFO0=
+github.com/openmcp-project/control-plane-operator v0.1.19 h1:ablgax+3hv6HR4jNVijLGQW5qTQZabIoz8bAygmrAY0=
+github.com/openmcp-project/control-plane-operator v0.1.19/go.mod h1:tiN7l8fitosSsjiy/3pOUZBMng2PPmOl+QSivDgI3qM=
 github.com/openmcp-project/controller-utils v0.23.2 h1:69zbDwFE7EYalvV1N0kOddkuFrCKLkIwcSzBIygGhq0=
 github.com/openmcp-project/controller-utils v0.23.2/go.mod h1:rycrEcxCREUTV3qu5KNNUcY1mfoQ8U4R5Mz/JG4DFKk=
 github.com/openmcp-project/openmcp-operator/api v0.17.0 h1:dhRbaGawtRx6Kd4oUbw5gSBnukEsS0xH29aTRjWIevY=

--- a/internal/controller/crossplane_controller.go
+++ b/internal/controller/crossplane_controller.go
@@ -499,20 +499,23 @@ func discoverCrossplaneImagePullSecrets(xpversions []v1alpha1.CrossplaneVersion)
 }
 
 func (r *CrossplaneReconciler) registerReconcilers(juggler *juggler.Juggler, logger logr.Logger, mcpClient client.Client) {
-	fr := fluxcd.NewFluxReconciler(logger, r.PlatformCluster.Client(), mcpClient, sputils.LabelComponentName)
+	fr := fluxcd.NewFluxReconciler(logger, r.PlatformCluster.Client(), mcpClient, sputils.LabelComponentName).
+		WithLabelFunc(sputils.LabelFunc(component.ComponentNameCrossplane))
 	fr.RegisterType(
 		&component.Crossplane{},
 	)
 	juggler.RegisterReconciler(fr)
 
-	or := object.NewReconciler(logger, mcpClient, sputils.LabelComponentName)
+	or := object.NewReconciler(logger, mcpClient, sputils.LabelComponentName).
+		WithLabelFunc(sputils.LabelFunc(component.ComponentNameCrossplane))
 	or.RegisterType(
 		&component.Secret{},
 		&component.CrossplaneProvider{},
 	)
 	juggler.RegisterReconciler(or)
 
-	por := object.NewReconciler(logger, r.PlatformCluster.Client(), sputils.LabelComponentName)
+	por := object.NewReconciler(logger, r.PlatformCluster.Client(), sputils.LabelComponentName).
+		WithLabelFunc(sputils.LabelFunc(component.ComponentNameCrossplane))
 	por.RegisterType(
 		&component.PlatformSecret{},
 	)

--- a/pkg/utils/meta.go
+++ b/pkg/utils/meta.go
@@ -2,6 +2,7 @@
 package utils
 
 import (
+	"github.com/openmcp-project/control-plane-operator/pkg/juggler"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -37,4 +38,15 @@ func IsManaged() client.MatchingLabels {
 // HasComponentLabel returns a client.ListOption that matches objects with the component label.
 func HasComponentLabel() client.ListOption {
 	return client.HasLabels{LabelComponentName}
+}
+
+// LabelFunc sets the `managedBy` label to the passed in `managedByValue`
+// and the `component` label to the name of the component the function is called with.
+func LabelFunc(managedByValue string) juggler.LabelFunc {
+	return func(comp juggler.Component) map[string]string {
+		return map[string]string{
+			labelManagedBy:     managedByValue,
+			LabelComponentName: comp.GetName(),
+		}
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the `managedBy` label set by the `FluxReconciler` and `ObjectReconciler`.
This is the follow-up of https://github.com/openmcp-project/control-plane-operator/issues/104

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The original issue only mentions the `FluxReconciler`. I guess `ObjectReconciler` is supposed to behave the same way.
And i suggest we drop the `componentLabelName` in the constructors when we move the `juggler` package out of `control-plane-operator`.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Managed components are properly labelled as managed by `service-provider-crossplane` instead of `control-plane-operator`
```
