### PR TITLE
feat: Watch referenced secrets and trigger reconciliation on update

### DIFF
--- a/cmd/service-provider-crossplane/main.go
+++ b/cmd/service-provider-crossplane/main.go
@@ -373,6 +373,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 		OnboardingCluster:    onboardingCluster,
 		Recorder:             mgr.GetEventRecorderFor("sp-crossplane-controller"),
 		RecieveEventsChannel: reconcileEventsCh,
+		SecretsNamespace:     os.Getenv(openmcpconstv1alpha1.EnvVariablePodNamespace),
 	}
 	if err := crossplaneReconciler.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to create controller Crossplane: %w", err)

--- a/internal/controller/crossplane_controller.go
+++ b/internal/controller/crossplane_controller.go
@@ -40,7 +40,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	controllerutil2 "github.com/openmcp-project/controller-utils/pkg/controller"
 
 	"github.com/openmcp-project/control-plane-operator/api/v1beta1"
 	clustersv1alpha1 "github.com/openmcp-project/openmcp-operator/api/clusters/v1alpha1"
@@ -78,7 +81,8 @@ var (
 )
 
 const (
-	requestSuffixMCP = "--mcp"
+	requestSuffixMCP          = "--mcp"
+	defaultProviderConfigName = "default"
 )
 
 // CrossplaneReconciler reconciles a Crossplane object
@@ -89,6 +93,7 @@ type CrossplaneReconciler struct {
 	Recorder                record.EventRecorder
 	RequeueStore            *smartrequeue.Store
 	RecieveEventsChannel    <-chan event.GenericEvent
+	SecretsNamespace        string
 }
 
 // Reconcile reconciles the Crossplane instance.
@@ -114,7 +119,7 @@ func (r *CrossplaneReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	// Get ProviderConfig from Platform cluster
 	pc := &v1alpha1.ProviderConfig{}
-	if err := r.PlatformCluster.Client().Get(ctx, types.NamespacedName{Name: "default"}, pc); err != nil {
+	if err := r.PlatformCluster.Client().Get(ctx, types.NamespacedName{Name: defaultProviderConfigName}, pc); err != nil {
 		return requeueEntry.ReturnError(err)
 	}
 
@@ -710,7 +715,61 @@ func (r *CrossplaneReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.Crossplane{}).
 		WatchesRawSource(source.Channel(r.RecieveEventsChannel, &handler.EnqueueRequestForObject{})).
+		WatchesRawSource(source.Kind(
+			r.PlatformCluster.Cluster().GetCache(),
+			&corev1.Secret{},
+			handler.TypedEnqueueRequestsFromMapFunc(r.mapSecretToRequests),
+			controllerutil2.ToTypedPredicate[*corev1.Secret](
+				predicate.NewPredicateFuncs(func(obj client.Object) bool {
+					return obj.GetNamespace() == r.SecretsNamespace
+				}),
+			),
+		)).
 		Complete(r)
+}
+
+func (r *CrossplaneReconciler) mapSecretToRequests(ctx context.Context, secret *corev1.Secret) []ctrl.Request {
+	log := log.FromContext(ctx)
+
+	providerConfig := &v1alpha1.ProviderConfig{}
+	if err := r.PlatformCluster.Client().Get(ctx, types.NamespacedName{Name: "default"}, providerConfig); err != nil {
+		log.Error(err, "failed to get ProviderConfig while mapping secret")
+		return nil
+	}
+
+	if !isSecretReferencedInProviderConfig(providerConfig, secret.Name) {
+		return nil
+	}
+
+	crossplanesList := &v1alpha1.CrossplaneList{}
+	if err := r.OnboardingCluster.Client().List(ctx, crossplanesList); err != nil {
+		log.Error(err, "failed to list Crossplane resources")
+		return nil
+	}
+
+	log.Info("Source secret changed, triggering reconciliation", "secret", secret.Name)
+
+	requests := make([]ctrl.Request, 0, len(crossplanesList.Items))
+	for _, crossplaneInstance := range crossplanesList.Items {
+		requests = append(requests, ctrl.Request{
+			NamespacedName: types.NamespacedName{Name: crossplaneInstance.Name, Namespace: crossplaneInstance.Namespace},
+		})
+	}
+	return requests
+}
+
+func isSecretReferencedInProviderConfig(pc *v1alpha1.ProviderConfig, secretName string) bool {
+	for _, versions := range pc.Spec.CrossplaneVersions {
+		if versions.Chart.SecretRef.Name == secretName || versions.Image.SecretRef.Name == secretName {
+			return true
+		}
+	}
+	for _, pullSecret := range pc.Spec.Providers.ImagePullSecrets {
+		if pullSecret.Name == secretName {
+			return true
+		}
+	}
+	return false
 }
 
 func getMCPPermissions() []clustersv1alpha1.PermissionsRequest {

--- a/internal/controller/crossplane_controller.go
+++ b/internal/controller/crossplane_controller.go
@@ -732,7 +732,7 @@ func (r *CrossplaneReconciler) mapSecretToRequests(ctx context.Context, secret *
 	log := log.FromContext(ctx)
 
 	providerConfig := &v1alpha1.ProviderConfig{}
-	if err := r.PlatformCluster.Client().Get(ctx, types.NamespacedName{Name: "default"}, providerConfig); err != nil {
+	if err := r.PlatformCluster.Client().Get(ctx, types.NamespacedName{Name: defaultProviderConfigName}, providerConfig); err != nil {
 		log.Error(err, "failed to get ProviderConfig while mapping secret")
 		return nil
 	}

--- a/internal/controller/crossplane_controller_test.go
+++ b/internal/controller/crossplane_controller_test.go
@@ -25,13 +25,17 @@ import (
 	crossplanev1beta1 "github.com/crossplane/crossplane/apis/pkg/v1beta1"
 	"github.com/openmcp-project/control-plane-operator/pkg/juggler"
 	"github.com/openmcp-project/control-plane-operator/pkg/utils/rcontext"
+	"github.com/openmcp-project/controller-utils/pkg/clusters"
 	commonapi "github.com/openmcp-project/openmcp-operator/api/common"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/openmcp-project/service-provider-crossplane/api/v1alpha1"
+	"github.com/openmcp-project/service-provider-crossplane/internal/scheme"
 	"github.com/openmcp-project/service-provider-crossplane/pkg/component"
 )
 
@@ -656,5 +660,355 @@ func Test_buildComponents(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func Test_isSecretReferencedInProviderConfig(t *testing.T) {
+	tests := []struct {
+		name       string
+		pc         *v1alpha1.ProviderConfig
+		secretName string
+		want       bool
+	}{
+		{
+			name: "matches chart pull secret",
+			pc: &v1alpha1.ProviderConfig{
+				Spec: v1alpha1.ProviderConfigSpec{
+					CrossplaneVersions: []v1alpha1.CrossplaneVersion{
+						{
+							Version: "v1.0.0",
+							Chart:   v1alpha1.ChartSpec{URL: "https://charts.example.com/1", SecretRef: commonapi.LocalObjectReference{Name: "chart-secret"}},
+							Image:   v1alpha1.ImageSpec{URL: "https://images.example.com/1"},
+						},
+					},
+					Providers: v1alpha1.CrossplaneProviders{},
+				},
+			},
+			secretName: "chart-secret",
+			want:       true,
+		},
+		{
+			name: "matches image pull secret",
+			pc: &v1alpha1.ProviderConfig{
+				Spec: v1alpha1.ProviderConfigSpec{
+					CrossplaneVersions: []v1alpha1.CrossplaneVersion{
+						{
+							Version: "v1.0.0",
+							Chart:   v1alpha1.ChartSpec{URL: "https://charts.example.com/1"},
+							Image:   v1alpha1.ImageSpec{URL: "https://images.example.com/1", SecretRef: commonapi.LocalObjectReference{Name: "image-secret"}},
+						},
+					},
+					Providers: v1alpha1.CrossplaneProviders{},
+				},
+			},
+			secretName: "image-secret",
+			want:       true,
+		},
+		{
+			name: "matches provider image pull secret",
+			pc: &v1alpha1.ProviderConfig{
+				Spec: v1alpha1.ProviderConfigSpec{
+					CrossplaneVersions: []v1alpha1.CrossplaneVersion{
+						{
+							Version: "v1.0.0",
+							Chart:   v1alpha1.ChartSpec{URL: "https://charts.example.com/1"},
+							Image:   v1alpha1.ImageSpec{URL: "https://images.example.com/1"},
+						},
+					},
+					Providers: v1alpha1.CrossplaneProviders{
+						ImagePullSecrets: []commonapi.LocalObjectReference{
+							{Name: "provider-pull-secret"},
+						},
+					},
+				},
+			},
+			secretName: "provider-pull-secret",
+			want:       true,
+		},
+		{
+			name: "matches secret in second version entry",
+			pc: &v1alpha1.ProviderConfig{
+				Spec: v1alpha1.ProviderConfigSpec{
+					CrossplaneVersions: []v1alpha1.CrossplaneVersion{
+						{
+							Version: "v1.0.0",
+							Chart:   v1alpha1.ChartSpec{URL: "https://charts.example.com/1"},
+							Image:   v1alpha1.ImageSpec{URL: "https://images.example.com/1"},
+						},
+						{
+							Version: "v2.0.0",
+							Chart:   v1alpha1.ChartSpec{URL: "https://charts.example.com/2", SecretRef: commonapi.LocalObjectReference{Name: "v2-chart-secret"}},
+							Image:   v1alpha1.ImageSpec{URL: "https://images.example.com/2"},
+						},
+					},
+					Providers: v1alpha1.CrossplaneProviders{},
+				},
+			},
+			secretName: "v2-chart-secret",
+			want:       true,
+		},
+		{
+			name: "does not match unrelated secret",
+			pc: &v1alpha1.ProviderConfig{
+				Spec: v1alpha1.ProviderConfigSpec{
+					CrossplaneVersions: []v1alpha1.CrossplaneVersion{
+						{
+							Version: "v1.0.0",
+							Chart:   v1alpha1.ChartSpec{URL: "https://charts.example.com/1", SecretRef: commonapi.LocalObjectReference{Name: "chart-secret"}},
+							Image:   v1alpha1.ImageSpec{URL: "https://images.example.com/1", SecretRef: commonapi.LocalObjectReference{Name: "image-secret"}},
+						},
+					},
+					Providers: v1alpha1.CrossplaneProviders{
+						ImagePullSecrets: []commonapi.LocalObjectReference{
+							{Name: "provider-pull-secret"},
+						},
+					},
+				},
+			},
+			secretName: "unrelated-secret",
+			want:       false,
+		},
+		{
+			name: "empty provider config - no secrets referenced",
+			pc: &v1alpha1.ProviderConfig{
+				Spec: v1alpha1.ProviderConfigSpec{
+					CrossplaneVersions: []v1alpha1.CrossplaneVersion{},
+					Providers:          v1alpha1.CrossplaneProviders{},
+				},
+			},
+			secretName: "any-secret",
+			want:       false,
+		},
+		{
+			name: "empty secret refs - no match",
+			pc: &v1alpha1.ProviderConfig{
+				Spec: v1alpha1.ProviderConfigSpec{
+					CrossplaneVersions: []v1alpha1.CrossplaneVersion{
+						{
+							Version: "v1.0.0",
+							Chart:   v1alpha1.ChartSpec{URL: "https://charts.example.com/1"},
+							Image:   v1alpha1.ImageSpec{URL: "https://images.example.com/1"},
+						},
+					},
+					Providers: v1alpha1.CrossplaneProviders{},
+				},
+			},
+			secretName: "some-secret",
+			want:       false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isSecretReferencedInProviderConfig(tt.pc, tt.secretName)
+			if got != tt.want {
+				t.Errorf("isSecretReferencedInProviderConfig() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_mapSecretToRequests(t *testing.T) {
+	tests := []struct {
+		name                string
+		secret              *corev1.Secret
+		providerConfig      *v1alpha1.ProviderConfig
+		crossplaneInstances []client.Object
+		wantRequests        []ctrl.Request
+	}{
+		{
+			name: "referenced secret triggers reconciliation for all Crossplane instances",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "chart-secret",
+					Namespace: "sp-namespace",
+				},
+			},
+			providerConfig: &v1alpha1.ProviderConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: defaultProviderConfigName,
+				},
+				Spec: v1alpha1.ProviderConfigSpec{
+					CrossplaneVersions: []v1alpha1.CrossplaneVersion{
+						{
+							Version: "v1.0.0",
+							Chart:   v1alpha1.ChartSpec{URL: "https://charts.example.com/1", SecretRef: commonapi.LocalObjectReference{Name: "chart-secret"}},
+							Image:   v1alpha1.ImageSpec{URL: "https://images.example.com/1"},
+						},
+					},
+					Providers: v1alpha1.CrossplaneProviders{},
+				},
+			},
+			crossplaneInstances: []client.Object{
+				&v1alpha1.Crossplane{
+					ObjectMeta: metav1.ObjectMeta{Name: "xp-1", Namespace: "ns-1"},
+				},
+				&v1alpha1.Crossplane{
+					ObjectMeta: metav1.ObjectMeta{Name: "xp-2", Namespace: "ns-2"},
+				},
+			},
+			wantRequests: []ctrl.Request{
+				{NamespacedName: client.ObjectKey{Name: "xp-1", Namespace: "ns-1"}},
+				{NamespacedName: client.ObjectKey{Name: "xp-2", Namespace: "ns-2"}},
+			},
+		},
+		{
+			name: "unreferenced secret returns no requests",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "unrelated-secret",
+					Namespace: "sp-namespace",
+				},
+			},
+			providerConfig: &v1alpha1.ProviderConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: defaultProviderConfigName,
+				},
+				Spec: v1alpha1.ProviderConfigSpec{
+					CrossplaneVersions: []v1alpha1.CrossplaneVersion{
+						{
+							Version: "v1.0.0",
+							Chart:   v1alpha1.ChartSpec{URL: "https://charts.example.com/1", SecretRef: commonapi.LocalObjectReference{Name: "chart-secret"}},
+							Image:   v1alpha1.ImageSpec{URL: "https://images.example.com/1"},
+						},
+					},
+					Providers: v1alpha1.CrossplaneProviders{},
+				},
+			},
+			crossplaneInstances: []client.Object{
+				&v1alpha1.Crossplane{
+					ObjectMeta: metav1.ObjectMeta{Name: "xp-1", Namespace: "ns-1"},
+				},
+			},
+			wantRequests: nil,
+		},
+		{
+			name: "referenced secret with no Crossplane instances returns empty",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "chart-secret",
+					Namespace: "sp-namespace",
+				},
+			},
+			providerConfig: &v1alpha1.ProviderConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: defaultProviderConfigName,
+				},
+				Spec: v1alpha1.ProviderConfigSpec{
+					CrossplaneVersions: []v1alpha1.CrossplaneVersion{
+						{
+							Version: "v1.0.0",
+							Chart:   v1alpha1.ChartSpec{URL: "https://charts.example.com/1", SecretRef: commonapi.LocalObjectReference{Name: "chart-secret"}},
+							Image:   v1alpha1.ImageSpec{URL: "https://images.example.com/1"},
+						},
+					},
+					Providers: v1alpha1.CrossplaneProviders{},
+				},
+			},
+			crossplaneInstances: nil,
+			wantRequests:        []ctrl.Request{},
+		},
+		{
+			name: "provider image pull secret triggers reconciliation",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "provider-pull-secret",
+					Namespace: "sp-namespace",
+				},
+			},
+			providerConfig: &v1alpha1.ProviderConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: defaultProviderConfigName,
+				},
+				Spec: v1alpha1.ProviderConfigSpec{
+					CrossplaneVersions: []v1alpha1.CrossplaneVersion{
+						{
+							Version: "v1.0.0",
+							Chart:   v1alpha1.ChartSpec{URL: "https://charts.example.com/1"},
+							Image:   v1alpha1.ImageSpec{URL: "https://images.example.com/1"},
+						},
+					},
+					Providers: v1alpha1.CrossplaneProviders{
+						ImagePullSecrets: []commonapi.LocalObjectReference{
+							{Name: "provider-pull-secret"},
+						},
+					},
+				},
+			},
+			crossplaneInstances: []client.Object{
+				&v1alpha1.Crossplane{
+					ObjectMeta: metav1.ObjectMeta{Name: "xp-1", Namespace: "ns-1"},
+				},
+			},
+			wantRequests: []ctrl.Request{
+				{NamespacedName: client.ObjectKey{Name: "xp-1", Namespace: "ns-1"}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Build fake platform client with ProviderConfig
+			platformClient := fake.NewClientBuilder().
+				WithScheme(scheme.Platform).
+				WithObjects(tt.providerConfig).
+				Build()
+
+			// Build fake onboarding client with Crossplane instances
+			onboardingBuilder := fake.NewClientBuilder().
+				WithScheme(scheme.Onboarding)
+			if len(tt.crossplaneInstances) > 0 {
+				onboardingBuilder = onboardingBuilder.WithObjects(tt.crossplaneInstances...)
+			}
+			onboardingClient := onboardingBuilder.Build()
+
+			r := &CrossplaneReconciler{
+				PlatformCluster:   clusters.NewTestClusterFromClient("platform", platformClient),
+				OnboardingCluster: clusters.NewTestClusterFromClient("onboarding", onboardingClient),
+			}
+
+			got := r.mapSecretToRequests(context.Background(), tt.secret)
+
+			if tt.wantRequests == nil {
+				if got != nil {
+					t.Errorf("mapSecretToRequests() = %v, want nil", got)
+				}
+				return
+			}
+
+			if len(got) != len(tt.wantRequests) {
+				t.Fatalf("mapSecretToRequests() returned %d requests, want %d", len(got), len(tt.wantRequests))
+			}
+			for i, req := range got {
+				if req.NamespacedName != tt.wantRequests[i].NamespacedName {
+					t.Errorf("mapSecretToRequests()[%d] = %v, want %v", i, req.NamespacedName, tt.wantRequests[i].NamespacedName)
+				}
+			}
+		})
+	}
+}
+
+func Test_mapSecretToRequests_providerConfigNotFound(t *testing.T) {
+	// Platform client with no ProviderConfig — simulates it not existing
+	platformClient := fake.NewClientBuilder().
+		WithScheme(scheme.Platform).
+		Build()
+	onboardingClient := fake.NewClientBuilder().
+		WithScheme(scheme.Onboarding).
+		Build()
+
+	r := &CrossplaneReconciler{
+		PlatformCluster:   clusters.NewTestClusterFromClient("platform", platformClient),
+		OnboardingCluster: clusters.NewTestClusterFromClient("onboarding", onboardingClient),
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "some-secret",
+			Namespace: "sp-namespace",
+		},
+	}
+
+	got := r.mapSecretToRequests(context.Background(), secret)
+	if got != nil {
+		t.Errorf("mapSecretToRequests() = %v, want nil when ProviderConfig not found", got)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a watch on referenced pull secrets in the Platform cluster so that changes immediately trigger reconciliation of all Crossplane instances.

**Which issue(s) this PR fixes**:
Fixes https://github.com/openmcp-project/backlog/issues/553

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
Watch referenced pull secrets and trigger reconciliation on change
```
