### PR TITLE
fix: prefix chart pull secret copy to prevent name collisions

### DIFF
--- a/internal/controller/crossplane_controller.go
+++ b/internal/controller/crossplane_controller.go
@@ -83,6 +83,7 @@ var (
 const (
 	requestSuffixMCP          = "--mcp"
 	defaultProviderConfigName = "default"
+	secretNamePrefix          = "sp-crossplane-"
 )
 
 // CrossplaneReconciler reconciles a Crossplane object
@@ -450,10 +451,18 @@ func buildComponents(ctx context.Context, client client.Client, xp *v1alpha1.Cro
 	}
 	xpContainerImagePullSecrets := discoverCrossplaneImagePullSecrets(xp.Spec, pc.Spec.CrossplaneVersions)
 
+	var prefixedChartPullSecret string
+	if xpHelmChartPullSecret.Name != "" {
+		prefixedChartPullSecret, err = prefixSecretName(xpHelmChartPullSecret.Name)
+		if err != nil {
+			return nil, fmt.Errorf("error generating secret name: %w", err)
+		}
+	}
+
 	xpComp := &component.Crossplane{
 		Enabled:              enabled,
 		Config:               &xp.Spec,
-		ChartPullSecretName:  xpHelmChartPullSecret.Name,
+		ChartPullSecretName:  prefixedChartPullSecret,
 		ImagePullSecretNames: extractSecretNames(xpContainerImagePullSecrets),
 		CABundleRef:          pc.Spec.CABundleRef,
 	}
@@ -485,7 +494,7 @@ func buildComponents(ctx context.Context, client client.Client, xp *v1alpha1.Cro
 				Namespace: podNs,
 			},
 			Target: types.NamespacedName{
-				Name:      xpHelmChartPullSecret.Name,
+				Name:      prefixedChartPullSecret,
 				Namespace: rcontext.TenantNamespace(ctx),
 			},
 			Enabled: xpComp.IsEnabled(),
@@ -860,4 +869,12 @@ func (r *CrossplaneReconciler) removeFinalizer(ctx context.Context, object clien
 
 func (r *CrossplaneReconciler) hasFinalizer(object client.Object, finalizer string) bool {
 	return controllerutil.ContainsFinalizer(object, finalizer)
+}
+
+// prefixSecretName adds the "sp-eso-" prefix to the given secret name
+// to prevent name collisions in namespaces where multiple service providers operate.
+// If the resulting name exceeds 63 characters (K8s limit), it will be truncated
+// and a hash suffix appended for uniqueness via ShortenToXCharacters.
+func prefixSecretName(secretName string) (string, error) {
+	return controllerutil2.ShortenToXCharacters(fmt.Sprintf("%s%s", secretNamePrefix, secretName), controllerutil2.K8sMaxNameLength)
 }

--- a/internal/controller/crossplane_controller.go
+++ b/internal/controller/crossplane_controller.go
@@ -871,7 +871,7 @@ func (r *CrossplaneReconciler) hasFinalizer(object client.Object, finalizer stri
 	return controllerutil.ContainsFinalizer(object, finalizer)
 }
 
-// prefixSecretName adds the "sp-eso-" prefix to the given secret name
+// prefixSecretName adds the "sp-crossplane-" prefix to the given secret name
 // to prevent name collisions in namespaces where multiple service providers operate.
 // If the resulting name exceeds 63 characters (K8s limit), it will be truncated
 // and a hash suffix appended for uniqueness via ShortenToXCharacters.

--- a/internal/controller/crossplane_controller_test.go
+++ b/internal/controller/crossplane_controller_test.go
@@ -19,7 +19,9 @@ package controller
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	crossplanev1beta1 "github.com/crossplane/crossplane/apis/pkg/v1beta1"
@@ -27,6 +29,8 @@ import (
 	"github.com/openmcp-project/control-plane-operator/pkg/utils/rcontext"
 	"github.com/openmcp-project/controller-utils/pkg/clusters"
 	commonapi "github.com/openmcp-project/openmcp-operator/api/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -273,7 +277,7 @@ func Test_buildComponents(t *testing.T) {
 				&component.Crossplane{
 					Enabled:              true,
 					Config:               &v1alpha1.CrossplaneSpec{Version: "v2.0.0", Providers: []*v1alpha1.CrossplaneProviderConfig{{Name: "provider-1", Version: "v0.1.0"}}},
-					ChartPullSecretName:  "other-chart-secret",
+					ChartPullSecretName:  fmt.Sprintf("%s%s", secretNamePrefix, "other-chart-secret"),
 					ImagePullSecretNames: []string{"other-image-secret"},
 				},
 				&component.CrossplaneProvider{
@@ -284,7 +288,7 @@ func Test_buildComponents(t *testing.T) {
 				&component.PlatformSecret{
 					SourceClient: nil,
 					Source:       client.ObjectKey{Name: "other-chart-secret", Namespace: "pod-namespace"},
-					Target:       client.ObjectKey{Name: "other-chart-secret", Namespace: "tenant-namespace"},
+					Target:       client.ObjectKey{Name: fmt.Sprintf("%s%s", secretNamePrefix, "other-chart-secret"), Namespace: "tenant-namespace"},
 					Enabled:      true,
 				},
 				&component.Secret{
@@ -359,7 +363,7 @@ func Test_buildComponents(t *testing.T) {
 						Version:   "v1.0.0",
 						Providers: []*v1alpha1.CrossplaneProviderConfig{{Name: "provider-1", Version: "v0.1.0"}},
 					},
-					ChartPullSecretName:  "chart-secret",
+					ChartPullSecretName:  fmt.Sprintf("%s%s", secretNamePrefix, "chart-secret"),
 					ImagePullSecretNames: []string{"image-secret"},
 				},
 				&component.CrossplaneProvider{
@@ -370,7 +374,7 @@ func Test_buildComponents(t *testing.T) {
 				&component.PlatformSecret{
 					SourceClient: nil,
 					Source:       client.ObjectKey{Name: "chart-secret", Namespace: "pod-namespace"},
-					Target:       client.ObjectKey{Name: "chart-secret", Namespace: "tenant-namespace"},
+					Target:       client.ObjectKey{Name: fmt.Sprintf("%s%s", secretNamePrefix, "chart-secret"), Namespace: "tenant-namespace"},
 					Enabled:      true,
 				},
 				&component.Secret{
@@ -433,7 +437,7 @@ func Test_buildComponents(t *testing.T) {
 						Version:   "v1.0.0",
 						Providers: []*v1alpha1.CrossplaneProviderConfig{{Name: "provider-1", Version: "v0.1.0"}},
 					},
-					ChartPullSecretName:  "chart-secret",
+					ChartPullSecretName:  fmt.Sprintf("%s%s", secretNamePrefix, "chart-secret"),
 					ImagePullSecretNames: []string{"image-secret"},
 				},
 				&component.CrossplaneProvider{
@@ -444,7 +448,7 @@ func Test_buildComponents(t *testing.T) {
 				&component.PlatformSecret{
 					SourceClient: nil,
 					Source:       client.ObjectKey{Name: "chart-secret", Namespace: "pod-namespace"},
-					Target:       client.ObjectKey{Name: "chart-secret", Namespace: "tenant-namespace"},
+					Target:       client.ObjectKey{Name: fmt.Sprintf("%s%s", secretNamePrefix, "chart-secret"), Namespace: "tenant-namespace"},
 					Enabled:      false,
 				},
 				&component.Secret{
@@ -1042,5 +1046,25 @@ func Test_mapSecretToRequests_providerConfigNotFound(t *testing.T) {
 	got := r.mapSecretToRequests(context.Background(), secret)
 	if got != nil {
 		t.Errorf("mapSecretToRequests() = %v, want nil when ProviderConfig not found", got)
+	}
+}
+
+func Test_prefixSecretName(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantLen int // expected max length
+		wantErr bool
+	}{
+		{"short name", "privateregcred", 27, false}, // "sp-crossplane-" + 14 chars
+		{"long name truncated", strings.Repeat("a", 60), 63, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := prefixSecretName(tt.input)
+			require.NoError(t, err)
+			assert.True(t, strings.HasPrefix(got, secretNamePrefix))
+			assert.LessOrEqual(t, len(got), 63)
+		})
 	}
 }

--- a/internal/controller/crossplane_controller_test.go
+++ b/internal/controller/crossplane_controller_test.go
@@ -1051,13 +1051,11 @@ func Test_mapSecretToRequests_providerConfigNotFound(t *testing.T) {
 
 func Test_prefixSecretName(t *testing.T) {
 	tests := []struct {
-		name    string
-		input   string
-		wantLen int // expected max length
-		wantErr bool
+		name  string
+		input string
 	}{
-		{"short name", "privateregcred", 27, false}, // "sp-crossplane-" + 14 chars
-		{"long name truncated", strings.Repeat("a", 60), 63, false},
+		{"short name", "privateregcred"},
+		{"long name truncated", strings.Repeat("a", 60)},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
On-behalf-of: @SAP christopher.junk@sap.com

**What this PR does / why we need it**:
Generate service provider specific name for chart pull secret copies to prevent name collisions when multiple service providers copy the same pull secret.

**Which issue(s) this PR fixes**:
Part of https://github.com/openmcp-project/backlog/issues/557

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```fix operator
generate service provider specific name for chart pull secret copies
```
