### PR TITLE
fix: platform secret orphan detector context

### DIFF
--- a/pkg/component/platform_secret_component.go
+++ b/pkg/component/platform_secret_component.go
@@ -35,6 +35,7 @@ func (s *PlatformSecret) OrphanDetectorContext() object.DetectorContext {
 		FilterCriteria: object.FilterCriteria{
 			utils.IsManaged(),
 			utils.HasComponentLabel(),
+			client.InNamespace(s.Target.Namespace),
 		},
 		ConvertFunc: func(list client.ObjectList) []juggler.Component {
 			var secrets []juggler.Component //nolint:prealloc

--- a/pkg/component/platform_secret_component_test.go
+++ b/pkg/component/platform_secret_component_test.go
@@ -109,7 +109,7 @@ func Test_PlatformSecret(t *testing.T) {
 					canBuildAndReconcile(nil),
 					implementsOrphanedObjectsDetector(
 						listTypeIs(&corev1.SecretList{}),
-						hasFilterCriteria(2),
+						hasFilterCriteria(3, client.InNamespace(pSecretA.Namespace)),
 						canConvert(&corev1.SecretList{Items: []corev1.Secret{*pSecretA}}, 1),
 						canCheckSame(&PlatformSecret{Target: client.ObjectKeyFromObject(pSecretA)}, &PlatformSecret{Target: client.ObjectKeyFromObject(pSecretA)}, true),
 						canCheckSame(&PlatformSecret{Target: client.ObjectKeyFromObject(pSecretA)}, &PlatformSecret{Target: client.ObjectKeyFromObject(pSecretB)}, false),

--- a/pkg/component/utils_test.go
+++ b/pkg/component/utils_test.go
@@ -246,9 +246,13 @@ func listTypeIs(sample client.ObjectList) orphanedObjectsDetectorValidationFunc 
 	}
 }
 
-func hasFilterCriteria(count int) orphanedObjectsDetectorValidationFunc {
+func hasFilterCriteria(count int, opts ...client.ListOption) orphanedObjectsDetectorValidationFunc {
 	return func(t *testing.T, ctx context.Context, dc object.DetectorContext) {
+		t.Helper()
 		assert.Len(t, dc.FilterCriteria, count)
+		for _, o := range opts {
+			assert.Contains(t, dc.FilterCriteria, o)
+		}
 	}
 }
 


### PR DESCRIPTION
On-behalf-of: @SAP christopher.junk@sap.com

**What this PR does / why we need it**:
Adds namespace filter criteria to platform secret orphan detector context.

**Which issue(s) this PR fixes**:
Fixes #105 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
fix missing namespace filter criteria in platform secret orphan detection
```
