### PR TITLE
fix: nil pointer dereference in discoverCrossplaneImagePullSecrets

### DIFF
--- a/internal/controller/crossplane_controller.go
+++ b/internal/controller/crossplane_controller.go
@@ -672,7 +672,7 @@ func extractHelmChartPullSecretForVersion(targetVersion string, xpversions []v1a
 func discoverCrossplaneImagePullSecrets(spec v1alpha1.CrossplaneSpec, xpversions []v1alpha1.CrossplaneVersion) []commonapi.LocalObjectReference {
 	secrets := make([]commonapi.LocalObjectReference, 0, len(xpversions))
 	for _, v := range xpversions {
-		if spec.Version == v.Version {
+		if spec.Version == v.Version && v.Image != nil {
 			secrets = append(secrets, v.Image.SecretRef)
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a nil pointer dereference panic introduced by #108, which made `CrossplaneVersion.Image` optional (`*ImageSpec`). The `discoverCrossplaneImagePullSecrets` function was not updated to guard against a nil `Image` before accessing its `SecretRef` field.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fix panic when CrossplaneVersion.Image is omitted in ProviderConfig. A nil pointer dereference in discoverCrossplaneImagePullSecrets caused the controller to crash for setups not using a private image registry.
```