### PR TITLE
chore: rename API group to crossplane.services.open-control-plane.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The `ProviderConfig` is stored in the Platform cluster and therefore in the resp
 The name of the `ProviderConfig` must match the `--provider-name` argument that is passed to the service provider crossplane operator.
 
 ```yaml
-apiVersion: crossplane.services.openmcp.cloud/v1alpha1
+apiVersion: crossplane.services.open-control-plane.io/v1alpha1
 kind: ProviderConfig
 metadata:
   name: crossplane
@@ -97,7 +97,7 @@ NOTE: `ProvierConfig.spec.versions[].chart.url` needs to be image URL to an OCI 
 ### Install a Crossplane instance
 
 ```yaml
-apiVersion: crossplane.services.openmcp.cloud/v1alpha1
+apiVersion: crossplane.services.open-control-plane.io/v1alpha1
 kind: Crossplane
 metadata:
   name: crossplane-sample

--- a/api/crds/manifests/crossplane.services.open-control-plane.io_crossplanes.yaml
+++ b/api/crds/manifests/crossplane.services.open-control-plane.io_crossplanes.yaml
@@ -6,9 +6,9 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.20.1
   labels:
     openmcp.cloud/cluster: onboarding
-  name: crossplanes.crossplane.services.openmcp.cloud
+  name: crossplanes.crossplane.services.open-control-plane.io
 spec:
-  group: crossplane.services.openmcp.cloud
+  group: crossplane.services.open-control-plane.io
   names:
     kind: Crossplane
     listKind: CrossplaneList

--- a/api/crds/manifests/crossplane.services.open-control-plane.io_providerconfigs.yaml
+++ b/api/crds/manifests/crossplane.services.open-control-plane.io_providerconfigs.yaml
@@ -6,9 +6,9 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.20.1
   labels:
     openmcp.cloud/cluster: platform
-  name: providerconfigs.crossplane.services.openmcp.cloud
+  name: providerconfigs.crossplane.services.open-control-plane.io
 spec:
-  group: crossplane.services.openmcp.cloud
+  group: crossplane.services.open-control-plane.io
   names:
     kind: ProviderConfig
     listKind: ProviderConfigList

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the  v1alpha1 API group.
 // +kubebuilder:object:generate=true
-// +groupName=crossplane.services.openmcp.cloud
+// +groupName=crossplane.services.open-control-plane.io
 package v1alpha1
 
 import (
@@ -27,7 +27,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects.
-	GroupVersion = schema.GroupVersion{Group: "crossplane.services.openmcp.cloud", Version: "v1alpha1"}
+	GroupVersion = schema.GroupVersion{Group: "crossplane.services.open-control-plane.io", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = runtime.NewSchemeBuilder(func(scheme *runtime.Scheme) error {

--- a/config/crd/bases/crossplane.services.openmcp.cloud_crossplanes.yaml
+++ b/config/crd/bases/crossplane.services.openmcp.cloud_crossplanes.yaml
@@ -8,7 +8,7 @@ metadata:
     openmcp.cloud/cluster: onboarding
   name: crossplanes.crossplane.services.openmcp.cloud
 spec:
-  group: crossplane.services.openmcp.cloud
+  group: crossplane.services.open-control-plane.io
   names:
     kind: Crossplane
     listKind: CrossplaneList

--- a/config/crd/bases/crossplane.services.openmcp.cloud_providerconfigs.yaml
+++ b/config/crd/bases/crossplane.services.openmcp.cloud_providerconfigs.yaml
@@ -8,7 +8,7 @@ metadata:
     openmcp.cloud/cluster: platform
   name: providerconfigs.crossplane.services.openmcp.cloud
 spec:
-  group: crossplane.services.openmcp.cloud
+  group: crossplane.services.open-control-plane.io
   names:
     kind: ProviderConfig
     listKind: ProviderConfigList

--- a/config/samples/v1alpha1_crossplane.yaml
+++ b/config/samples/v1alpha1_crossplane.yaml
@@ -1,4 +1,4 @@
-apiVersion: crossplane.services.openmcp.cloud/v1alpha1
+apiVersion: crossplane.services.open-control-plane.io/v1alpha1
 kind: Crossplane
 metadata:
   name: crossplane-sample

--- a/config/samples/v1alpha1_providerconfig.yaml
+++ b/config/samples/v1alpha1_providerconfig.yaml
@@ -1,4 +1,4 @@
-apiVersion: crossplane.services.openmcp.cloud/v1alpha1
+apiVersion: crossplane.services.open-control-plane.io/v1alpha1
 kind: ProviderConfig
 metadata:
   name: default

--- a/docs/configuration/custom-ca.md
+++ b/docs/configuration/custom-ca.md
@@ -17,7 +17,7 @@ The `CABundleRef` property in the `ProviderConfig` allows you to configure custo
 The `caBundleRef` field is an optional reference to a Kubernetes ConfigMap containing your custom CA certificate bundle:
 
 ```yaml
-apiVersion: crossplane.services.openmcp.cloud/v1alpha1
+apiVersion: crossplane.services.open-control-plane.io/v1alpha1
 kind: ProviderConfig
 metadata:
   name: default

--- a/internal/controller/crossplane_controller.go
+++ b/internal/controller/crossplane_controller.go
@@ -79,7 +79,7 @@ var (
 	// FinalizerAccess is the finalizer for access requests.
 	FinalizerAccess = v1alpha1.GroupVersion.Group + "/mcp-access"
 
-	controllerName = v1alpha1.GroupVersion.Group
+	// controllerName = v1alpha1.GroupVersion.Group
 	// TODO: In order to avoid issues during the api group change with existing instances,
 	// the name of the cluster access reconciler needs to stay the same.
 	// This should be changed when there will be a solution for this.
@@ -367,7 +367,7 @@ func (r *CrossplaneReconciler) setupFluxKubeconfig(ctx context.Context, req ctrl
 	// Get MCP AccessRequest to use for Flux
 	mcpAccessRequest := &clustersv1alpha1.AccessRequest{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      clusteraccess.StableRequestName(controllerName, req) + requestSuffixMCP,
+			Name:      clusteraccess.StableRequestName(clusterAccessReconcilerName, req) + requestSuffixMCP,
 			Namespace: tenantNamespace,
 		},
 	}

--- a/internal/controller/crossplane_controller.go
+++ b/internal/controller/crossplane_controller.go
@@ -80,6 +80,10 @@ var (
 	FinalizerAccess = v1alpha1.GroupVersion.Group + "/mcp-access"
 
 	controllerName = v1alpha1.GroupVersion.Group
+	// TODO: In order to avoid issues during the api group change with existing instances,
+	// the name of the cluster access reconciler needs to stay the same.
+	// This should be changed when there will be a solution for this.
+	clusterAccessReconcilerName = "crossplane.services.openmcp.cloud"
 )
 
 const (
@@ -796,7 +800,7 @@ func (r *CrossplaneReconciler) registerReconcilers(juggler *juggler.Juggler, log
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *CrossplaneReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	r.ClusterAccessReconciler = clusteraccess.NewClusterAccessReconciler(r.PlatformCluster.Client(), controllerName)
+	r.ClusterAccessReconciler = clusteraccess.NewClusterAccessReconciler(r.PlatformCluster.Client(), clusterAccessReconcilerName)
 	r.ClusterAccessReconciler.
 		WithMCPScheme(scheme.MCP).
 		WithRetryInterval(10 * time.Second).

--- a/test/e2e/crossplane_test.go
+++ b/test/e2e/crossplane_test.go
@@ -177,8 +177,8 @@ func TestInvalidVersion(t *testing.T) {
 				}
 				obj := &unstructured.Unstructured{}
 				obj.SetGroupVersionKind(schema.GroupVersionKind{
-					Group:   v1alpha1.GroupVersion.String(),
-					Version: "v1alpha1",
+					Group:   v1alpha1.GroupVersion.Group,
+					Version: v1alpha1.GroupVersion.Version,
 					Kind:    "Crossplane",
 				})
 				obj.SetName(mcpName)
@@ -228,8 +228,8 @@ func TestInvalidProviderVersion(t *testing.T) {
 				}
 				obj := &unstructured.Unstructured{}
 				obj.SetGroupVersionKind(schema.GroupVersionKind{
-					Group:   v1alpha1.GroupVersion.String(),
-					Version: "v1alpha1",
+					Group:   v1alpha1.GroupVersion.Group,
+					Version: v1alpha1.GroupVersion.Version,
 					Kind:    "Crossplane",
 				})
 				obj.SetName(mcpName)
@@ -286,8 +286,8 @@ func TestInvalidVersionRecovery(t *testing.T) {
 				}
 				obj := &unstructured.Unstructured{}
 				obj.SetGroupVersionKind(schema.GroupVersionKind{
-					Group:   v1alpha1.GroupVersion.String(),
-					Version: "v1alpha1",
+					Group:   v1alpha1.GroupVersion.Group,
+					Version: v1alpha1.GroupVersion.Version,
 					Kind:    "Crossplane",
 				})
 				obj.SetName(mcpName)
@@ -317,8 +317,8 @@ func TestInvalidVersionRecovery(t *testing.T) {
 				}
 				obj := &unstructured.Unstructured{}
 				obj.SetGroupVersionKind(schema.GroupVersionKind{
-					Group:   v1alpha1.GroupVersion.String(),
-					Version: "v1alpha1",
+					Group:   v1alpha1.GroupVersion.Group,
+					Version: v1alpha1.GroupVersion.Version,
 					Kind:    "Crossplane",
 				})
 				obj.SetName(mcpName)
@@ -354,8 +354,8 @@ func TestInvalidVersionRecovery(t *testing.T) {
 			}
 			obj := &unstructured.Unstructured{}
 			obj.SetGroupVersionKind(schema.GroupVersionKind{
-				Group:   v1alpha1.GroupVersion.String(),
-				Version: "v1alpha1",
+				Group:   v1alpha1.GroupVersion.Group,
+				Version: v1alpha1.GroupVersion.Version,
 				Kind:    "Crossplane",
 			})
 			obj.SetName(mcpName)
@@ -391,8 +391,8 @@ func TestInvalidProviderVersionRecovery(t *testing.T) {
 				}
 				obj := &unstructured.Unstructured{}
 				obj.SetGroupVersionKind(schema.GroupVersionKind{
-					Group:   v1alpha1.GroupVersion.String(),
-					Version: "v1alpha1",
+					Group:   v1alpha1.GroupVersion.Group,
+					Version: v1alpha1.GroupVersion.Version,
 					Kind:    "Crossplane",
 				})
 				obj.SetName(mcpName)
@@ -428,8 +428,8 @@ func TestInvalidProviderVersionRecovery(t *testing.T) {
 				}
 				obj := &unstructured.Unstructured{}
 				obj.SetGroupVersionKind(schema.GroupVersionKind{
-					Group:   v1alpha1.GroupVersion.String(),
-					Version: "v1alpha1",
+					Group:   v1alpha1.GroupVersion.Group,
+					Version: v1alpha1.GroupVersion.Version,
 					Kind:    "Crossplane",
 				})
 				obj.SetName(mcpName)
@@ -470,8 +470,8 @@ func TestInvalidProviderVersionRecovery(t *testing.T) {
 			}
 			obj := &unstructured.Unstructured{}
 			obj.SetGroupVersionKind(schema.GroupVersionKind{
-				Group:   v1alpha1.GroupVersion.String(),
-				Version: "v1alpha1",
+				Group:   v1alpha1.GroupVersion.Group,
+				Version: v1alpha1.GroupVersion.Version,
 				Kind:    "Crossplane",
 			})
 			obj.SetName(mcpName)

--- a/test/e2e/crossplane_test.go
+++ b/test/e2e/crossplane_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/openmcp-project/service-provider-crossplane/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -176,7 +177,7 @@ func TestInvalidVersion(t *testing.T) {
 				}
 				obj := &unstructured.Unstructured{}
 				obj.SetGroupVersionKind(schema.GroupVersionKind{
-					Group:   "crossplane.services.openmcp.cloud",
+					Group:   v1alpha1.GroupVersion.String(),
 					Version: "v1alpha1",
 					Kind:    "Crossplane",
 				})
@@ -227,7 +228,7 @@ func TestInvalidProviderVersion(t *testing.T) {
 				}
 				obj := &unstructured.Unstructured{}
 				obj.SetGroupVersionKind(schema.GroupVersionKind{
-					Group:   "crossplane.services.openmcp.cloud",
+					Group:   v1alpha1.GroupVersion.String(),
 					Version: "v1alpha1",
 					Kind:    "Crossplane",
 				})
@@ -285,7 +286,7 @@ func TestInvalidVersionRecovery(t *testing.T) {
 				}
 				obj := &unstructured.Unstructured{}
 				obj.SetGroupVersionKind(schema.GroupVersionKind{
-					Group:   "crossplane.services.openmcp.cloud",
+					Group:   v1alpha1.GroupVersion.String(),
 					Version: "v1alpha1",
 					Kind:    "Crossplane",
 				})
@@ -316,7 +317,7 @@ func TestInvalidVersionRecovery(t *testing.T) {
 				}
 				obj := &unstructured.Unstructured{}
 				obj.SetGroupVersionKind(schema.GroupVersionKind{
-					Group:   "crossplane.services.openmcp.cloud",
+					Group:   v1alpha1.GroupVersion.String(),
 					Version: "v1alpha1",
 					Kind:    "Crossplane",
 				})
@@ -353,7 +354,7 @@ func TestInvalidVersionRecovery(t *testing.T) {
 			}
 			obj := &unstructured.Unstructured{}
 			obj.SetGroupVersionKind(schema.GroupVersionKind{
-				Group:   "crossplane.services.openmcp.cloud",
+				Group:   v1alpha1.GroupVersion.String(),
 				Version: "v1alpha1",
 				Kind:    "Crossplane",
 			})
@@ -390,7 +391,7 @@ func TestInvalidProviderVersionRecovery(t *testing.T) {
 				}
 				obj := &unstructured.Unstructured{}
 				obj.SetGroupVersionKind(schema.GroupVersionKind{
-					Group:   "crossplane.services.openmcp.cloud",
+					Group:   v1alpha1.GroupVersion.String(),
 					Version: "v1alpha1",
 					Kind:    "Crossplane",
 				})
@@ -427,7 +428,7 @@ func TestInvalidProviderVersionRecovery(t *testing.T) {
 				}
 				obj := &unstructured.Unstructured{}
 				obj.SetGroupVersionKind(schema.GroupVersionKind{
-					Group:   "crossplane.services.openmcp.cloud",
+					Group:   v1alpha1.GroupVersion.String(),
 					Version: "v1alpha1",
 					Kind:    "Crossplane",
 				})
@@ -469,7 +470,7 @@ func TestInvalidProviderVersionRecovery(t *testing.T) {
 			}
 			obj := &unstructured.Unstructured{}
 			obj.SetGroupVersionKind(schema.GroupVersionKind{
-				Group:   "crossplane.services.openmcp.cloud",
+				Group:   v1alpha1.GroupVersion.String(),
 				Version: "v1alpha1",
 				Kind:    "Crossplane",
 			})

--- a/test/e2e/onboarding/crossplane.yaml
+++ b/test/e2e/onboarding/crossplane.yaml
@@ -1,4 +1,4 @@
-apiVersion: crossplane.services.openmcp.cloud/v1alpha1
+apiVersion: crossplane.services.open-control-plane.io/v1alpha1
 kind: Crossplane
 metadata:
   name: test-mcp

--- a/test/e2e/platform/providerconfig.yaml
+++ b/test/e2e/platform/providerconfig.yaml
@@ -1,4 +1,4 @@
-apiVersion: crossplane.services.openmcp.cloud/v1alpha1
+apiVersion: crossplane.services.open-control-plane.io/v1alpha1
 kind: ProviderConfig
 metadata:
   name: crossplane


### PR DESCRIPTION
**What this PR does / why we need it**:
Rename the Kubernetes API group domain from `crossplane.services.openmcp.cloud` to `crossplane.services.open-control-plane.io`.

Updated files:
- `api/*/groupversion_info.go`: `+groupName` marker and `GroupVersion.Group` constant
- `internal/`: kubebuilder RBAC markers
- `test/`: e2e test fixtures and Go test files
- `docs/`, `README.md`, `config/`: documentation and sample manifests
- Regenerated via `task generate`: CRD manifests, RBAC roles, deepcopy functions

**Which issue(s) this PR fixes**:
Part of https://github.com/openmcp-project/backlog/issues/533

**Special notes for your reviewer**:
Only the exact full API group string is replaced. Go files are classified by claude to distinguish API group references (replaced) from label/annotation key constants (left unchanged). `pkg/` and `cmd/` are excluded entirely. CRD manifests and RBAC roles are fully regenerated via `task generate`.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Renamed Kubernetes API group from `crossplane.services.openmcp.cloud` to `crossplane.services.open-control-plane.io`.
```