### PR TITLE
refactor: providerconfig name match provider-name argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,13 @@ spec:
 ### Configure a `ProviderConfig`
 A `ProviderConfig` is an API where you can configure an allow-list of Crossplane and provider installations in your `ManagedControlPlane`.
 The `ProviderConfig` is stored in the Platform cluster and therefore in the responsibility realm of the platform owner.
+The name of the `ProviderConfig` must match the `--provider-name` argument that is passed to the service provider crossplane operator.
 
 ```yaml
 apiVersion: crossplane.services.openmcp.cloud/v1alpha1
 kind: ProviderConfig
 metadata:
-  name: default
+  name: crossplane
 spec:
   versions:
     - version: v2.0.2

--- a/cmd/service-provider-crossplane/main.go
+++ b/cmd/service-provider-crossplane/main.go
@@ -220,6 +220,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 	probeAddr, _ := cmd.Flags().GetString("health-probe-bind-address")
 	secureMetrics, _ := cmd.Flags().GetBool("metrics-secure")
 	enableHTTP2, _ := cmd.Flags().GetBool("enable-http2")
+	providerName, _ := cmd.Flags().GetString("provider-name")
 
 	var tlsOpts []func(*tls.Config)
 
@@ -374,6 +375,7 @@ func runCommand(cmd *cobra.Command, _ []string) error {
 		Recorder:             mgr.GetEventRecorder("sp-crossplane-controller"),
 		RecieveEventsChannel: reconcileEventsCh,
 		SecretsNamespace:     os.Getenv(openmcpconstv1alpha1.EnvVariablePodNamespace),
+		ProviderName:         providerName,
 	}
 	if err := crossplaneReconciler.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to create controller Crossplane: %w", err)

--- a/internal/controller/crossplane_controller.go
+++ b/internal/controller/crossplane_controller.go
@@ -83,9 +83,8 @@ var (
 )
 
 const (
-	requestSuffixMCP          = "--mcp"
-	defaultProviderConfigName = "default"
-	secretNamePrefix          = "sp-crossplane-"
+	requestSuffixMCP = "--mcp"
+	secretNamePrefix = "sp-crossplane-"
 )
 
 // CrossplaneReconciler reconciles a Crossplane object
@@ -97,6 +96,7 @@ type CrossplaneReconciler struct {
 	RequeueStore            *smartrequeue.Store
 	RecieveEventsChannel    <-chan event.GenericEvent
 	SecretsNamespace        string
+	ProviderName            string
 }
 
 // Reconcile reconciles the Crossplane instance.
@@ -151,10 +151,10 @@ func (r *CrossplaneReconciler) doReconcile(ctx context.Context, req ctrl.Request
 
 	// Get ProviderConfig from Platform cluster
 	pc := &v1alpha1.ProviderConfig{}
-	if err := r.PlatformCluster.Client().Get(ctx, types.NamespacedName{Name: defaultProviderConfigName}, pc); err != nil {
-		addCondition(ConditionTypeReconciled, metav1.ConditionFalse, ReasonProviderConfigNotFound, fmt.Sprintf("ProviderConfig '%s' not found: %v", defaultProviderConfigName, err))
+	if err := r.PlatformCluster.Client().Get(ctx, types.NamespacedName{Name: r.ProviderName}, pc); err != nil {
+		addCondition(ConditionTypeReconciled, metav1.ConditionFalse, ReasonProviderConfigNotFound, fmt.Sprintf("ProviderConfig '%s' not found: %v", r.ProviderName, err))
 		rr.ReconcileError = errutils.WithReason(err, ReasonProviderConfigNotFound)
-		r.Recorder.Eventf(xp, nil, corev1.EventTypeWarning, ReasonProviderConfigNotFound, "Reconcile", "ProviderConfig '%s' not found: %v", defaultProviderConfigName, err)
+		r.Recorder.Eventf(xp, nil, corev1.EventTypeWarning, ReasonProviderConfigNotFound, "Reconcile", "ProviderConfig '%s' not found: %v", r.ProviderName, err)
 		return
 	}
 
@@ -830,7 +830,7 @@ func (r *CrossplaneReconciler) mapSecretToRequests(ctx context.Context, secret *
 	log := log.FromContext(ctx)
 
 	providerConfig := &v1alpha1.ProviderConfig{}
-	if err := r.PlatformCluster.Client().Get(ctx, types.NamespacedName{Name: defaultProviderConfigName}, providerConfig); err != nil {
+	if err := r.PlatformCluster.Client().Get(ctx, types.NamespacedName{Name: r.ProviderName}, providerConfig); err != nil {
 		log.Error(err, "failed to get ProviderConfig while mapping secret")
 		return nil
 	}

--- a/internal/controller/crossplane_controller_test.go
+++ b/internal/controller/crossplane_controller_test.go
@@ -43,6 +43,8 @@ import (
 	"github.com/openmcp-project/service-provider-crossplane/pkg/component"
 )
 
+const TestProviderName = "crossplane-test"
+
 func TestDeduplicateSecretRefs(t *testing.T) {
 	testCases := []struct {
 		desc     string
@@ -861,7 +863,7 @@ func Test_mapSecretToRequests(t *testing.T) {
 			},
 			providerConfig: &v1alpha1.ProviderConfig{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: defaultProviderConfigName,
+					Name: TestProviderName,
 				},
 				Spec: v1alpha1.ProviderConfigSpec{
 					CrossplaneVersions: []v1alpha1.CrossplaneVersion{
@@ -897,7 +899,7 @@ func Test_mapSecretToRequests(t *testing.T) {
 			},
 			providerConfig: &v1alpha1.ProviderConfig{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: defaultProviderConfigName,
+					Name: TestProviderName,
 				},
 				Spec: v1alpha1.ProviderConfigSpec{
 					CrossplaneVersions: []v1alpha1.CrossplaneVersion{
@@ -927,7 +929,7 @@ func Test_mapSecretToRequests(t *testing.T) {
 			},
 			providerConfig: &v1alpha1.ProviderConfig{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: defaultProviderConfigName,
+					Name: TestProviderName,
 				},
 				Spec: v1alpha1.ProviderConfigSpec{
 					CrossplaneVersions: []v1alpha1.CrossplaneVersion{
@@ -953,7 +955,7 @@ func Test_mapSecretToRequests(t *testing.T) {
 			},
 			providerConfig: &v1alpha1.ProviderConfig{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: defaultProviderConfigName,
+					Name: TestProviderName,
 				},
 				Spec: v1alpha1.ProviderConfigSpec{
 					CrossplaneVersions: []v1alpha1.CrossplaneVersion{
@@ -999,6 +1001,7 @@ func Test_mapSecretToRequests(t *testing.T) {
 			r := &CrossplaneReconciler{
 				PlatformCluster:   clusters.NewTestClusterFromClient("platform", platformClient),
 				OnboardingCluster: clusters.NewTestClusterFromClient("onboarding", onboardingClient),
+				ProviderName:      TestProviderName,
 			}
 
 			got := r.mapSecretToRequests(context.Background(), tt.secret)
@@ -1034,6 +1037,7 @@ func Test_mapSecretToRequests_providerConfigNotFound(t *testing.T) {
 	r := &CrossplaneReconciler{
 		PlatformCluster:   clusters.NewTestClusterFromClient("platform", platformClient),
 		OnboardingCluster: clusters.NewTestClusterFromClient("onboarding", onboardingClient),
+		ProviderName:      TestProviderName,
 	}
 
 	secret := &corev1.Secret{

--- a/test/e2e/platform/providerconfig.yaml
+++ b/test/e2e/platform/providerconfig.yaml
@@ -1,7 +1,7 @@
 apiVersion: crossplane.services.openmcp.cloud/v1alpha1
 kind: ProviderConfig
 metadata:
-  name: default
+  name: crossplane
 spec:
   versions:
     - version: "1.20.5"


### PR DESCRIPTION
**What this PR does / why we need it**:

The operator no longer searches its `ProviderConfig` with the name "default" but now with the name that is passed via the "--provider-name" argument.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The operator no longer searches its `ProviderConfig` with the name "default" but now with the name that is passed via the "--provider-name" argument.
```
