### PR TITLE
feat: user input error handling

### DIFF
--- a/internal/controller/crossplane_controller.go
+++ b/internal/controller/crossplane_controller.go
@@ -223,7 +223,7 @@ func (r *CrossplaneReconciler) doReconcileComponents(ctx context.Context, mcpCli
 
 	componentConditions, err := r.createOrUpdateCrossplaneInstance(ctx, mcpClient, xp, pc)
 	if err != nil {
-		rr.ReconcileError = errutils.WithReason(err, ReasonComponentReconcileFailed)
+		rr.ReconcileError = errutils.WithReason(errutils.IgnoreInvalidUserInput(err), ReasonComponentReconcileFailed)
 		rr.Conditions = overrideCondition(rr.Conditions, ConditionTypeReconciled, metav1.ConditionFalse, ReasonComponentBuildFailed, err.Error())
 		r.Recorder.Eventf(xp, nil, corev1.EventTypeWarning, ReasonComponentReconcileFailed, "Reconcile", "Failed to reconcile components: %v", err)
 		return
@@ -755,7 +755,7 @@ func extractHelmChartPullSecretForVersion(targetVersion string, xpversions []v1a
 	for _, v := range xpversions {
 		available = append(available, v.Version)
 	}
-	return nil, fmt.Errorf("requested version %q is not available, available versions: %v", targetVersion, available)
+	return nil, fmt.Errorf("%w: requested version %q is not available, available versions: %v", errutils.ErrInvalidUserInput, targetVersion, available)
 }
 
 func discoverCrossplaneImagePullSecrets(spec v1alpha1.CrossplaneSpec, xpversions []v1alpha1.CrossplaneVersion) []commonapi.LocalObjectReference {
@@ -922,7 +922,7 @@ func (r *CrossplaneReconciler) GetResolverFunc(providerConfig *v1alpha1.Provider
 			for _, v := range providerConfig.Spec.CrossplaneVersions {
 				available = append(available, v.Version)
 			}
-			return v1beta1.ComponentVersion{}, fmt.Errorf("requested version %q is not available, available versions: %v", version, available)
+			return v1beta1.ComponentVersion{}, fmt.Errorf("%w: requested version %q is not available, available versions: %v", errutils.ErrInvalidUserInput, version, available)
 		}
 
 		// Check if Provider is installable
@@ -936,10 +936,10 @@ func (r *CrossplaneReconciler) GetResolverFunc(providerConfig *v1alpha1.Provider
 						}, nil
 					}
 				}
-				return v1beta1.ComponentVersion{}, fmt.Errorf("requested version %q for provider %q is not available, available versions: %v", version, componentName, provider.Versions)
+				return v1beta1.ComponentVersion{}, fmt.Errorf("%w: requested version %q for provider %q is not available, available versions: %v", errutils.ErrInvalidUserInput, version, componentName, provider.Versions)
 			}
 		}
-		return v1beta1.ComponentVersion{}, fmt.Errorf("provider %q is not available in the ProviderConfig", componentName)
+		return v1beta1.ComponentVersion{}, fmt.Errorf("%w: provider %q is not available in the ProviderConfig", errutils.ErrInvalidUserInput, componentName)
 	}
 }
 

--- a/internal/controller/crossplane_controller_test.go
+++ b/internal/controller/crossplane_controller_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/openmcp-project/control-plane-operator/pkg/juggler"
 	"github.com/openmcp-project/control-plane-operator/pkg/utils/rcontext"
 	"github.com/openmcp-project/controller-utils/pkg/clusters"
+	errutils "github.com/openmcp-project/controller-utils/pkg/errors"
 	commonapi "github.com/openmcp-project/openmcp-operator/api/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -663,6 +664,58 @@ func Test_buildComponents(t *testing.T) {
 					t.Errorf("buildComponents() element %d not found in expected: %v", i, gotComponent)
 				}
 			}
+		})
+	}
+}
+
+func Test_extractHelmChartPullSecretForVersion(t *testing.T) {
+	versions := []v1alpha1.CrossplaneVersion{
+		{Version: "v1.0.0", Chart: v1alpha1.ChartSpec{SecretRef: commonapi.LocalObjectReference{Name: "secret-1"}}},
+		{Version: "v2.0.0", Chart: v1alpha1.ChartSpec{SecretRef: commonapi.LocalObjectReference{Name: "secret-2"}}},
+	}
+
+	_, err := extractHelmChartPullSecretForVersion("v3.0.0", versions)
+	assert.Error(t, err)
+	assert.Nil(t, errutils.IgnoreInvalidUserInput(err), "unsupported version error should be treated as invalid user input")
+}
+
+func Test_GetResolverFunc(t *testing.T) {
+	pc := &v1alpha1.ProviderConfig{
+		Spec: v1alpha1.ProviderConfigSpec{
+			CrossplaneVersions: []v1alpha1.CrossplaneVersion{
+				{Version: "v1.0.0", Chart: v1alpha1.ChartSpec{URL: "oci://charts/crossplane:v1.0.0"}},
+			},
+			Providers: v1alpha1.CrossplaneProviders{
+				AvailableProviders: []v1alpha1.AvailableCrossplaneProvider{
+					{Name: "provider-aws", Versions: []string{"v0.1.0"}, Package: "crossplane/provider-aws"},
+				},
+			},
+		},
+	}
+	r := &CrossplaneReconciler{}
+	resolve := r.GetResolverFunc(pc)
+
+	tests := []struct {
+		name          string
+		componentName string
+		version       string
+		wantErr       bool
+	}{
+		{"valid crossplane version", component.CrossplaneRelease, "v1.0.0", false},
+		{"unsupported crossplane version", component.CrossplaneRelease, "v9.9.9", true},
+		{"valid provider version", "provider-aws", "v0.1.0", false},
+		{"unsupported provider version", "provider-aws", "v9.9.9", true},
+		{"unknown provider", "provider-unknown", "v0.1.0", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := resolve(tt.componentName, tt.version)
+			if !tt.wantErr {
+				assert.NoError(t, err)
+				return
+			}
+			assert.Error(t, err)
+			assert.Nil(t, errutils.IgnoreInvalidUserInput(err), "version resolver error should be treated as invalid user input")
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces handling of user input errors to prevent reconciliation failures where a requeue won't fix the problem, e.g. a user requesting a Crossplane or Crossplane Provider version that is not available results in a status condition update that indicates the problem but won't requeue the object.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
user input error handling to prevent unnecessary requeues
```
